### PR TITLE
hdtest fix

### DIFF
--- a/VXWORKS/TOOLS/NATIVE/HDTEST/hdtest.c
+++ b/VXWORKS/TOOLS/NATIVE/HDTEST/hdtest.c
@@ -473,6 +473,9 @@ static int cleanup(HDTEST_HANDLE_T *h, int no)
 		/* printf("%d total errors\n", h->globerror ); */
 	}
 
+	if( h->return_teststatus ){
+		return h->globerror;
+	}
 	return no;
 }
 


### PR DESCRIPTION
**Fix:**
hdtest should return teststatus when argument -e is set, but -e has no effect. Instead hdtests returns always 0 when the test run is done, regardless if the test revealed errors.

**Feature-Add:**
In addition a new binary-mode is implemented, which writes the raw test results in memory, instead of a formatted string. This is to make it easier for the caller to process the results, as there is not need to parse a string.